### PR TITLE
🛠 fix: Build Timeout

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -10,6 +10,7 @@ timeZone = "Asia/Taipei"
 enableRobotsTXT = true
 paginate = 10
 summaryLength = 0
+timeout = "120s"
 
 [markup]
   [markup.goldmark]


### PR DESCRIPTION
When upgrading to Congo v2.8.0, the build time increases significantly. This PR aims to pass the build instead of fixing it.