### PR TITLE
✨ [feat] Carousel shortcode

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,5 +1,9 @@
-/* Enhenced abbr element for mobile and keyboard navigation */
-/* https://bitsofco.de/making-abbr-work-for-touchscreen-keyboard-mouse/ */
+/*
+==========================================================================
+Enhenced abbr element for mobile and keyboard navigation
+https://bitsofco.de/making-abbr-work-for-touchscreen-keyboard-mouse/
+==========================================================================
+*/
 abbr[title] {
   position: relative;
 
@@ -27,8 +31,12 @@ abbr[title]:focus::after {
   padding: 3px 5px;
 }
 
-/* Add icons to indicate external links */
-/* https://christianoliff.com/blog/styling-external-links-with-an-icon-in-css/ */
+/*
+==========================================================================
+Add icons to indicate external links
+https://christianoliff.com/blog/styling-external-links-with-an-icon-in-css/
+==========================================================================
+*/
 a svg {
   fill: var(--tw-prose-body);
   width: 0.6em;
@@ -38,9 +46,81 @@ a svg {
   display: inline-block;
 }
 
-/* Hugo sometimes renders empty p and a tags */
+/*
+==========================================================================
+Hugo sometimes renders empty p and a tags
+==========================================================================
+*/
 p:empty,
 a:empty,
 a svg:first-child {
   display: none;
+}
+
+/*
+==========================================================================
+Carousel shortcode
+https://blog.logrocket.com/modern-css-carousels-no-javascript-required/
+==========================================================================
+*/
+.carousel-scroller {
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+  scroll-marker-group: after;
+  position: relative;
+}
+.carousel-scroller::-webkit-scrollbar {
+  display: none;
+}
+
+.carousel-scroller > figure {
+  flex: 0 0 100%;
+  scroll-snap-align: start;
+  margin-block: 0;
+  margin-inline: 0 !important;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.carousel-scroller > figure picture {
+  display: block;
+  width: 100%;
+}
+
+.carousel-scroller > figure img {
+  display: block;
+  width: 100%;
+  height: auto;
+  margin-inline: 0;
+  border-radius: 0.375rem;
+}
+
+.carousel-scroller::scroll-marker-group {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 0;
+}
+
+.carousel-scroller > figure::scroll-marker {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgb(var(--color-neutral-300));
+  transition: background-color 0.2s;
+}
+
+.dark .carousel-scroller > figure::scroll-marker {
+  background: rgb(var(--color-neutral-600));
+}
+
+.carousel-scroller > figure::scroll-marker:target-current {
+  background: rgb(var(--color-primary-500));
+}
+
+.dark .carousel-scroller > figure::scroll-marker:target-current {
+  background: rgb(var(--color-primary-400));
 }

--- a/content/posts/2025-march-dump/index.zh-tw.md
+++ b/content/posts/2025-march-dump/index.zh-tw.md
@@ -22,9 +22,11 @@ coverCaption: "征服 Mission Peak！"
 
 雖然現在公司都有供三餐，所以我平日幾乎不怎麼需要自己打理三餐，但假日如果餐餐外食，在灣區還是有點太奢侈，於是又開始煮飯了。
 
-![煎鮭魚搭配炒蛋和蘑菇，擺盤在淺綠色餐盤上，背景為鍵盤和桌面。](mushroom-omelette-with-salmon.jpg "15 分鐘上桌系列之蘑菇炒蛋配香煎鮭魚")
-![簡單家常咖哩飯，內含雞肉、馬鈴薯和紅蘿蔔，盛放在淺色碗中。](curry-rice.jpg "~~很有進步空間的~~咖哩飯")
-![日式炒麵上覆蓋海苔、日式美乃滋和太陽蛋，擺放在淺綠色餐盤中。](yakisoba.jpg "怎麼好像意外成功的[日式炒麵](https://docs.tomy.me/yakisoba)")
+{{< carousel >}}
+{{< figure src="mushroom-omelette-with-salmon.jpg" alt="煎鮭魚搭配炒蛋和蘑菇，擺盤在淺綠色餐盤上，背景為鍵盤和桌面。" caption="15 分鐘上桌系列之蘑菇炒蛋配香煎鮭魚" >}}
+{{< figure src="curry-rice.jpg" alt="簡單家常咖哩飯，內含雞肉、馬鈴薯和紅蘿蔔，盛放在淺色碗中。" caption="~~很有進步空間的~~咖哩飯" >}}
+{{< figure src="yakisoba.jpg" alt="日式炒麵上覆蓋海苔、日式美乃滋和太陽蛋，擺放在淺綠色餐盤中。" caption="怎麼好像意外成功的[日式炒麵](https://docs.tomy.me/yakisoba)" >}}
+{{< /carousel >}}
 
 ## 🏞️ 放假出去玩 ⁽⁽ଘ( ˙꒳˙ )ଓ⁾⁾
 

--- a/layouts/_shortcodes/carousel.html
+++ b/layouts/_shortcodes/carousel.html
@@ -1,0 +1,8 @@
+{{ $caption := .Get "caption" }}
+
+<figure class="my-4">
+  <div class="carousel-scroller overflow-x-auto gap-2 flex">{{ .Inner }}</div>
+  {{ with $caption }}
+  <figcaption class="text-center mt-1">{{ . | markdownify }}</figcaption>
+  {{ end }}
+</figure>


### PR DESCRIPTION
This shortcode uses the CSS property `scroll-marker-group`, which is [not yet widely supported by browsers](https://caniuse.com/mdn-css_properties_scroll-marker-group).

Merge this after the browser is widely supported, or consider a polyfill or alternatives.
